### PR TITLE
[doc] document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and serve it as xml for usage with Yealink SIP phones.
 
 On your server:
 
-```
+```bash
 cp example-config.yaml config.yaml
 vim config.yaml
 python main.py
@@ -17,6 +17,11 @@ python main.py
 To enable the remote contacts, on your phone's web interface:
 - Directory / Remote Phone Book -> add URL, enable call lookup
 - Directory / Settings -> Move Remote Phone Book to enabled sections
+
+## Dependencies (e.g. on Debian)
+```bash
+apt install python3 (>= 3.6) python3-yaml (>= 5.1) python3-flask python3-waitress python3-lxml python3-vobject python3-requests
+```
 
 ## Acknowledgements:
 


### PR DESCRIPTION
Document dependencies in README.

As `yaml.full_load()` instead of `load()` is used at least yaml 5.1 is required.
As `f'strings'` are used at least Python 3.6 is required.