### PR TITLE
[fix]: add defaults for givenname and familyname

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -30,6 +30,8 @@ def vcf_to_xml(config, vcf):
     for vcard in vcards:
         input_counter += 1
         numbers = []
+        givenname = ''
+        familyname = ''
         for p in vcard.getChildren():
             if p.name == "N":
                 givenname = p.value.given


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "main.py", line 49, in <module>
    contacts = get_contacts()
  File "main.py", line 19, in get_contacts
    xml = vcf_to_xml(config, vcf)
  File "convert.py", line 53, in vcf_to_xml
    if givenname != "" and familyname != "":
UnboundLocalError: local variable 'givenname' referenced before assignment
```