### PR TITLE
Add Dockerfile and use pip for dependency management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-alpine
+ENV PYTHONUNBUFFERED=1
+WORKDIR /usr/src/carddav-to-yealink-remote
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD [ "python", "./main.py" ]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To enable the remote contacts, on your phone's web interface:
 ## Dependencies (e.g. on Debian)
 
 ```bash
-apt install python3 (>= 3.6) python3-yaml (>= 5.1) python3-flask python3-waitress python3-vobject python3-requests
+pip install -r requirements.txt
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ To enable the remote contacts, on your phone's web interface:
 - Directory / Settings -> Move Remote Phone Book to enabled sections
 
 
-## Dependencies (e.g. on Debian)
+## Dependencies
+
+You can manage the dependencies via the package manager of your Linux distribution (Debian or debian-based in this example):
+
+```bash
+apt install python3 (>= 3.6) python3-yaml (>= 5.1) python3-flask python3-waitress python3-vobject python3-requests
+```
+... or by using pip with the `requirements.txt` included in this repo:
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PyYAML
+flask
+waitress
+vobject
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML
+PyYAML >= 5.1
 flask
 waitress
 vobject

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML >= 5.1
+PyYAML>=5.1
 flask
 waitress
 vobject


### PR DESCRIPTION
I think using pip for handling of dependencies enables a more versatile approach since pip works the same on every platform, while apt does not.

I would also like to add the Dockerfile for easier deployment.